### PR TITLE
Improve Javadoc of JMoleculesDddRules

### DIFF
--- a/jmolecules-archunit/src/main/java/org/jmolecules/archunit/JMoleculesDddRules.java
+++ b/jmolecules-archunit/src/main/java/org/jmolecules/archunit/JMoleculesDddRules.java
@@ -49,6 +49,8 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
  * <ul>
  * <li>Aggregates only refer to entities that are declared to be part of it.</li>
  * <li>References to other aggregates are established via {@link Association}s or identifier references.</li>
+ * <li>Annotated identifiables do have an identifier.</li>
+ * <li>Value objects and identifiers do not refer to identifiables.</li>
  * </ul>
  * Those rules are mostly driven by what's been presented by John Sullivan in his blog post
  * <a href="http://scabl.blogspot.com/2015/04/aeddd-9.html">here</a>.
@@ -81,6 +83,8 @@ public class JMoleculesDddRules {
 	 * @return
 	 * @see #entitiesShouldBeDeclaredForUseInSameAggregate()
 	 * @see #aggregateReferencesShouldBeViaIdOrAssociation()
+	 * @see #annotatedEntitiesAndAggregatesNeedToHaveAnIdentifier()
+	 * @see #valueObjectsMustNotReferToIdentifiables()
 	 */
 	public static ArchRule all() {
 

--- a/jmolecules-archunit/src/main/java/org/jmolecules/archunit/JMoleculesDddRules.java
+++ b/jmolecules-archunit/src/main/java/org/jmolecules/archunit/JMoleculesDddRules.java
@@ -100,17 +100,17 @@ public class JMoleculesDddRules {
 	 * An {@link ArchRule} that verifies that fields that implement {@link Entity} within a type implementing
 	 * {@link AggregateRoot} declare the aggregate type as the owning aggregate.
 	 * <p />
-	 * <code>
-	 * class Customer implements AggregateRoot<Customer, CustomerId> { … }
-	 * class Address implements Entity<Customer, AddressId> { … }
+	 * <pre>
+	 * class Customer implements AggregateRoot&lt;Customer, CustomerId&gt; { … }
+	 * class Address implements Entity&lt;Customer, AddressId&gt; { … }
 	 *
-	 * class LineItem implements Entity<Order, LineItemId> { … }
-	 * class Order implements AggregateRoot<Order, OrderId> {
+	 * class LineItem implements Entity&lt;Order, LineItemId&gt; { … }
+	 * class Order implements AggregateRoot&lt;Order, OrderId&gt; {
 	 *
-	 *   List<LineItem> lineItems; // valid
+	 *   List&lt;LineItem&gt; lineItems; // valid
 	 *   Address shippingAddress; // invalid as Address is declared to belong to Customer
 	 * }
-	 * </code>
+	 * </pre>
 	 *
 	 * @return will never be {@literal null}.
 	 */
@@ -127,16 +127,16 @@ public class JMoleculesDddRules {
 	 * An {@link ArchRule} that ensures that one {@link AggregateRoot} does not reference another via the remote
 	 * AggregateRoot type but rather via their identifier type or an explicit {@link Association} type.
 	 * <p />
-	 * <code>
-	 * class Customer implements AggregateRoot<Customer, CustomerId> { … }
+	 * <pre>
+	 * class Customer implements AggregateRoot&lt;Customer, CustomerId&gt; { … }
 	 *
-	 * class Order implements AggregateRoot<Order, OrderId> {
+	 * class Order implements AggregateRoot&lt;Order, OrderId&gt; {
 	 *
 	 *   Customer customer; // invalid
 	 *   CustomerId customerId; // valid
-	 *   Association<Customer> customer; // valid
+	 *   Association&lt;Customer&gt; customer; // valid
 	 * }
-	 * </code>
+	 * </pre>
 	 *
 	 * @return will never be {@literal null}.
 	 */


### PR DESCRIPTION
While reading the Javadoc I noticed two issues:

1. The summaries did not contain all rules.
2. The code examples were rendered as a single line, see [entitiesShouldBeDeclaredForUseInSameAggregate()](https://javadoc.io/static/org.jmolecules.integrations/jmolecules-archunit/0.13.0/org/jmolecules/archunit/JMoleculesDddRules.html#entitiesShouldBeDeclaredForUseInSameAggregate()) for an example. (And IntelliJ did not render the generics correctly...)

This PR fixes both issues.