### PR TITLE
Expose ArchUnit predicate resideInLayer

### DIFF
--- a/jmolecules-archunit/src/main/java/org/jmolecules/archunit/JMoleculesArchitectureRules.java
+++ b/jmolecules-archunit/src/main/java/org/jmolecules/archunit/JMoleculesArchitectureRules.java
@@ -246,6 +246,25 @@ public class JMoleculesArchitectureRules {
 				.layer(HEXAGONAL_SECONDARY_ADAPTER).definedBy(layerType(SecondaryAdapter.class));
 	}
 
+	/**
+	 * ArchUnit {@link DescribedPredicate} accepting all classes, that reside in the given layer.
+	 *
+	 * <pre>
+	 * classes().that(resideInLayer(DomainLayer.class))...
+	 *
+	 * classes().that(...).should(ArchCondition.from(resideInLayer(DomainLayer.class)))...
+	 * </pre>
+	 *
+	 * @return will never be {@literal null}.
+	 * @see org.jmolecules.architecture.hexagonal
+	 * @see org.jmolecules.architecture.layered
+	 * @see org.jmolecules.architecture.onion.classical
+	 * @see org.jmolecules.architecture.onion.simplified
+	 */
+	public static DescribedPredicate<JavaClass> resideInLayer(Class<? extends Annotation> annotation) {
+		return new IsLayerType(annotation);
+	}
+
 	private static IsLayerType layerType(Class<? extends Annotation> annotation) {
 		return new IsLayerType(annotation);
 	}

--- a/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesArchitecturePredicatesTest.java
+++ b/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesArchitecturePredicatesTest.java
@@ -1,0 +1,32 @@
+package org.jmolecules.archunit;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import org.jmolecules.architecture.layered.ApplicationLayer;
+import org.jmolecules.archunit.layered.Layered;
+import org.jmolecules.archunit.layered.app.AppType;
+import org.jmolecules.archunit.layered.domain.DomainType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jmolecules.archunit.JMoleculesArchitectureRules.resideInLayer;
+
+/**
+ * Unit tests for exposed predicates.
+ *
+ * @author Roland Weisleder
+ */
+@AnalyzeClasses(packagesOf = Layered.class)
+class JMoleculesArchitecturePredicatesTest {
+
+    @ArchTest
+    void predicate_resideInLayer(JavaClasses types) {
+
+        DescribedPredicate<JavaClass> predicate = resideInLayer(ApplicationLayer.class);
+        assertThat(predicate)
+                .accepts(types.get(AppType.class))
+                .rejects(types.get(DomainType.class));
+    }
+}


### PR DESCRIPTION
This resolves the initial requirement mentioned in #100.

I'm not sure, if we should also expose predicates for DDD types, like `types.that(areValueObjects())`. If so, I'd create an additional PR.