### PR TITLE
Fix instantiation of records with multiple parameters

### DIFF
--- a/jmolecules-jpa/src/main/java/org/jmolecules/hibernate/RecordInstantiator.java
+++ b/jmolecules-jpa/src/main/java/org/jmolecules/hibernate/RecordInstantiator.java
@@ -20,7 +20,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.RecordComponent;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -74,9 +73,16 @@ public class RecordInstantiator implements EmbeddableInstantiator {
 		this.constructor = detectRecordConstructor(type, parameterTypes);
 
 		// Obtain parameter name indexes as they will be returned sorted alphabetically on instantiation
-		this.indexes = IntStream.range(0, components.length)
+		List<Integer> sortedParams = IntStream.range(0, components.length)
 				.mapToObj(it -> Map.entry(components[it].getName(), it))
-				.sorted(Comparator.comparing(Entry::getKey))
+				.sorted(Entry.comparingByKey())
+				.map(Entry::getValue)
+				.collect(Collectors.toList());
+
+		// Obtain indexes of alphabetically sorted parameters mapped to correct places in constructor
+		this.indexes = IntStream.range(0, components.length)
+				.mapToObj(idx -> Map.entry(sortedParams.get(idx), idx))
+				.sorted(Entry.comparingByKey())
 				.map(Entry::getValue)
 				.collect(Collectors.toList());
 	}

--- a/jmolecules-jpa/src/test/java/org/jmolecules/hibernate/RecordInstantiatorUnitTests.java
+++ b/jmolecules-jpa/src/test/java/org/jmolecules/hibernate/RecordInstantiatorUnitTests.java
@@ -29,7 +29,23 @@ import org.junit.jupiter.api.Test;
 class RecordInstantiatorUnitTests {
 
 	@Test // #98, #125
-	void instantiatesRecord() {
+	void instantiatesPersonRecord() {
+
+		RecordInstantiator instantiator = new RecordInstantiator(Person.class);
+
+		Object[] values = RecordInstantiator.IS_AFFECTED_HIBERNATE_VERSION
+				? new Object[] { "Matthews", "Dave" }
+				: new Object[] { "Dave", "Matthews" };
+
+		ValueAccess access = mock(ValueAccess.class);
+		doReturn(values).when(access).getValues();
+
+		assertThat(instantiator.instantiate(access, null))
+				.isEqualTo(new Person("Matthews", "Dave"));
+	}
+
+	@Test
+	void instantiatesAddressRecord() {
 
 		RecordInstantiator instantiator = new RecordInstantiator(Address.class);
 
@@ -43,6 +59,8 @@ class RecordInstantiatorUnitTests {
 		assertThat(instantiator.instantiate(access, null))
 				.isEqualTo(new Address("Longstreet", "12345", "Berlin", "Germany"));
 	}
+
+	record Person(String lastname, String firstname) {}
 
 	record Address(String street, String postalCode, String city, String country) {}
 }

--- a/jmolecules-jpa/src/test/java/org/jmolecules/hibernate/RecordInstantiatorUnitTests.java
+++ b/jmolecules-jpa/src/test/java/org/jmolecules/hibernate/RecordInstantiatorUnitTests.java
@@ -31,18 +31,18 @@ class RecordInstantiatorUnitTests {
 	@Test // #98, #125
 	void instantiatesRecord() {
 
-		RecordInstantiator instantiator = new RecordInstantiator(Person.class);
+		RecordInstantiator instantiator = new RecordInstantiator(Address.class);
 
 		Object[] values = RecordInstantiator.IS_AFFECTED_HIBERNATE_VERSION
-				? new Object[] { "Matthews", "Dave" }
-				: new Object[] { "Dave", "Matthews" };
+				? new Object[] { "Longstreet", "12345", "Berlin", "Germany" }
+				: new Object[] { "Berlin", "Germany", "12345", "Longstreet" };
 
 		ValueAccess access = mock(ValueAccess.class);
 		doReturn(values).when(access).getValues();
 
 		assertThat(instantiator.instantiate(access, null))
-				.isEqualTo(new Person("Matthews", "Dave"));
+				.isEqualTo(new Address("Longstreet", "12345", "Berlin", "Germany"));
 	}
 
-	record Person(String lastname, String firstname) {}
+	record Address(String street, String postalCode, String city, String country) {}
 }


### PR DESCRIPTION
This PR fixes RecordInstantiator, which is calling a record constructor with incorrectly ordered parameters.