### PR TITLE
Handle case of existing package-info.java file correctly and pick up …

### DIFF
--- a/jmolecules-apt/pom.xml
+++ b/jmolecules-apt/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>io.toolisticon.aptk</groupId>
 			<artifactId>aptk-tools</artifactId>
-			<version>0.23.0</version>
+			<version>0.24.0</version>
 		</dependency>
 
 		<dependency>

--- a/jmolecules-apt/src/main/java/org/jmolecules/annotation/processor/JMoleculesProcessor.java
+++ b/jmolecules-apt/src/main/java/org/jmolecules/annotation/processor/JMoleculesProcessor.java
@@ -127,7 +127,7 @@ public class JMoleculesProcessor implements Processor {
             Set<TypeElementWrapper> typesToCheck = packagesToCheck.stream()
                     .<TypeElement>flatMap(fqn -> PackageElementWrapper.wrap(
                             ToolingProvider.getTooling().getElements().getPackageElement(fqn))
-                            .filterEnclosedElements().applyFilter(AptkCoreMatchers.IS_TYPE_ELEMENT)
+                            .filterFlattenedEnclosedElementTree().applyFilter(AptkCoreMatchers.IS_TYPE_ELEMENT)
                             .getResult().stream())
                     .map(TypeElementWrapper::wrap)
                     .collect(Collectors.toSet());

--- a/jmolecules-apt/src/test/java/org/jmolecules/annotation/processor/JMoleculesProcessorUnitTests.java
+++ b/jmolecules-apt/src/test/java/org/jmolecules/annotation/processor/JMoleculesProcessorUnitTests.java
@@ -16,8 +16,8 @@
 package org.jmolecules.annotation.processor;
 
 import io.toolisticon.cute.Cute;
+import io.toolisticon.cute.CuteApi;
 import io.toolisticon.cute.CuteApi.CompilerMessageCheckComparisonType;
-
 import org.junit.jupiter.api.Test;
 
 /**
@@ -27,84 +27,92 @@ import org.junit.jupiter.api.Test;
  */
 class JMoleculesProcessorUnitTests {
 
-	@Test
-	void detectsInvalidAggregateRootReferenceInImplementingAggregate() {
+    CuteApi.BlackBoxTestSourceFilesAndProcessorInterface baseBlackBoxSetup = Cute.blackBoxTest()
+            .given()
+            .processor(JMoleculesProcessor.class);
 
-		assertFailed("MyAggregateRoot")
-				.atLine(8)
-				.contains("Invalid aggregate root reference!")
-				.executeTest();
-	}
 
-	@Test
-	void detectsInvalidAggregateRootReferenceInImplementingEntity() {
+    @Test
+    void detectsInvalidAggregateRootReferenceInImplementingAggregate() {
 
-		assertFailed("MyEntity")
-				.atLine(8)
-				.contains("Invalid aggregate root reference!")
-				.executeTest();
-	}
+        baseBlackBoxSetup.andSourceFiles(getSourceFile("MyAggregateRoot"))
+                .whenCompiled()
+                .thenExpectThat().compilationFails()
+                .andThat().compilerMessage().ofKindError().atLine(8)
+                .contains("Invalid aggregate root reference!")
+                .executeTest();
 
-	@Test
-	void detectsInvalidAggregateRootReferenceInAnnotatedAggregate() {
+    }
 
-		assertFailed("AnnotatedAggregateRoot")
-				.atLine(10)
-				.contains("Invalid aggregate root reference!")
-				.executeTest();
-	}
+    @Test
+    void detectsInvalidAggregateRootReferenceInImplementingAggregateWithPackageInfo() {
 
-	@Test
-	void detectsMissingIdentifierInAnnotatedAggregate() {
+        baseBlackBoxSetup.andSourceFiles(getSourceFile("MyAggregateRoot"), getSourceFile("package-info"))
+                .whenCompiled()
+                .thenExpectThat().compilationFails()
+                .andThat().compilerMessage().ofKindError().atLine(8)
+                .contains("Invalid aggregate root reference!")
+                .executeTest();
 
-		assertFailed("AnnotatedAggregateRoot")
-				.atLine(9)
-				.contains("identity")
-				.executeTest();
-	}
+    }
 
-	@Test
-	void passesAnnotatedAggregateRootWithFieldIdentity() {
-		assertSucceeded("WithFieldIdentity");
-	}
+    @Test
+    void detectsInvalidAggregateRootReferenceInImplementingEntity() {
 
-	@Test
-	void passesAnnotatedAggregateRootWithMethodIdentity() {
-		assertSucceeded("WithFieldIdentity");
-	}
+        baseBlackBoxSetup.andSourceFiles(getSourceFile("MyEntity"))
+                .whenCompiled()
+                .thenExpectThat().compilationFails()
+                .andThat().compilerMessage().ofKindError()
+                .atLine(8)
+                .contains("Invalid aggregate root reference!")
+                .executeTest();
 
-	private static CompilerMessageCheckComparisonType assertFailed(String source) {
+    }
 
-		String file = getSourceFile(source);
+    @Test
+    void detectsInvalidAggregateRootReferenceInAnnotatedAggregate() {
 
-		return Cute.blackBoxTest()
-				.given()
-				.processor(JMoleculesProcessor.class)
-				.andSourceFiles(file)
-				.whenCompiled()
-				.thenExpectThat()
-				.compilationFails()
-				.andThat()
-				.compilerMessage()
-				.ofKindError()
-				.atSource(file);
-	}
+        baseBlackBoxSetup.andSourceFiles(getSourceFile("AnnotatedAggregateRoot"))
+                .whenCompiled()
+                .thenExpectThat().compilationFails()
+                .andThat().compilerMessage().ofKindError()
+                .atLine(10)
+                .contains("Invalid aggregate root reference!")
+                .executeTest();
 
-	private static void assertSucceeded(String source) {
+    }
 
-		String file = getSourceFile(source);
+    @Test
+    void detectsMissingIdentifierInAnnotatedAggregate() {
 
-		Cute.blackBoxTest()
-				.given()
-				.processor(JMoleculesProcessor.class)
-				.andSourceFiles(file)
-				.whenCompiled()
-				.thenExpectThat()
-				.compilationSucceeds()
-				.executeTest();
-	}
+        baseBlackBoxSetup.andSourceFiles(getSourceFile("AnnotatedAggregateRoot"))
+                .whenCompiled()
+                .thenExpectThat().compilationFails()
+                .andThat().compilerMessage().ofKindError()
+                .atLine(9)
+                .contains("identity")
+                .executeTest();
 
-	private static String getSourceFile(String name) {
-		return "/example/" + name + ".java";
-	}
+    }
+
+    @Test
+    void passesAnnotatedAggregateRootWithFieldIdentity() {
+        baseBlackBoxSetup.andSourceFiles(getSourceFile("WithMethodIdentity"))
+                .whenCompiled()
+                .thenExpectThat().compilationSucceeds()
+                .executeTest();
+    }
+
+    @Test
+    void passesAnnotatedAggregateRootWithMethodIdentity() {
+        baseBlackBoxSetup.andSourceFiles(getSourceFile("WithFieldIdentity"))
+                .whenCompiled()
+                .thenExpectThat().compilationSucceeds()
+                .executeTest();
+    }
+
+
+    private static String getSourceFile(String name) {
+        return "/example/" + name + ".java";
+    }
 }

--- a/jmolecules-apt/src/test/java/org/jmolecules/annotation/processor/JMoleculesProcessorUnitTests.java
+++ b/jmolecules-apt/src/test/java/org/jmolecules/annotation/processor/JMoleculesProcessorUnitTests.java
@@ -45,6 +45,18 @@ class JMoleculesProcessorUnitTests {
     }
 
     @Test
+    void detectsInvalidAggregateRootReferenceInImplementingAggregateInNestedClass() {
+
+        baseBlackBoxSetup.andSourceFiles(getSourceFile("MyAggregateRootNested"))
+                .whenCompiled()
+                .thenExpectThat().compilationFails()
+                .andThat().compilerMessage().ofKindError().atLine(9)
+                .contains("Invalid aggregate root reference!")
+                .executeTest();
+
+    }
+
+    @Test
     void detectsInvalidAggregateRootReferenceInImplementingAggregateWithPackageInfo() {
 
         baseBlackBoxSetup.andSourceFiles(getSourceFile("MyAggregateRoot"), getSourceFile("package-info"))

--- a/jmolecules-apt/src/test/resources/example/AnnotatedAggregateRoot.java
+++ b/jmolecules-apt/src/test/resources/example/AnnotatedAggregateRoot.java
@@ -1,4 +1,4 @@
-package example;
+package org.jmolecules.annotation.processor.example;
 
 import org.jmolecules.ddd.annotation.AggregateRoot;
 

--- a/jmolecules-apt/src/test/resources/example/MyAggregateRoot.java
+++ b/jmolecules-apt/src/test/resources/example/MyAggregateRoot.java
@@ -1,4 +1,4 @@
-package example;
+package org.jmolecules.annotation.processor.example;
 
 import org.jmolecules.ddd.types.AggregateRoot;
 import org.jmolecules.ddd.types.Identifier;

--- a/jmolecules-apt/src/test/resources/example/MyAggregateRootNested.java
+++ b/jmolecules-apt/src/test/resources/example/MyAggregateRootNested.java
@@ -1,0 +1,17 @@
+package org.jmolecules.annotation.processor.example;
+
+import org.jmolecules.ddd.types.AggregateRoot;
+import org.jmolecules.ddd.types.Identifier;
+
+public class MyAggregateRootNested {
+    public static class MyAggregateRoot implements AggregateRoot<MyAggregateRoot, Identifier> {
+
+        MyAggregateRoot aggregate;
+        String foo;
+
+        @Override
+        public Identifier getId() {
+            return null;
+        }
+    }
+}

--- a/jmolecules-apt/src/test/resources/example/MyEntity.java
+++ b/jmolecules-apt/src/test/resources/example/MyEntity.java
@@ -1,4 +1,4 @@
-package example;
+package org.jmolecules.annotation.processor.example;
 
 import org.jmolecules.ddd.types.Entity;
 import org.jmolecules.ddd.types.Identifier;

--- a/jmolecules-apt/src/test/resources/example/ValidAggregateRoot.java
+++ b/jmolecules-apt/src/test/resources/example/ValidAggregateRoot.java
@@ -1,4 +1,4 @@
-package example;
+package org.jmolecules.annotation.processor.example;
 
 import org.jmolecules.ddd.types.AggregateRoot;
 import org.jmolecules.ddd.types.Identifier;

--- a/jmolecules-apt/src/test/resources/example/WithFieldIdentity.java
+++ b/jmolecules-apt/src/test/resources/example/WithFieldIdentity.java
@@ -1,4 +1,4 @@
-package example;
+package org.jmolecules.annotation.processor.example;
 
 import java.util.UUID;
 

--- a/jmolecules-apt/src/test/resources/example/WithMethodIdentity.java
+++ b/jmolecules-apt/src/test/resources/example/WithMethodIdentity.java
@@ -1,4 +1,4 @@
-package example;
+package org.jmolecules.annotation.processor.example;
 
 import org.jmolecules.ddd.annotation.AggregateRoot;
 import org.jmolecules.ddd.annotation.Identity;

--- a/jmolecules-apt/src/test/resources/example/package-info.java
+++ b/jmolecules-apt/src/test/resources/example/package-info.java
@@ -1,0 +1,1 @@
+package org.jmolecules.annotation.processor.example;


### PR DESCRIPTION
…even not annotated TypeElements via Packages.

This still won’t guarantee that all TypeElement will be used. But ensures that only one annotation must be present per package.