### PR TITLE
Issue/referencing aggregate in collection not validated

### DIFF
--- a/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesDddRulesUnitTest.java
+++ b/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesDddRulesUnitTest.java
@@ -69,7 +69,8 @@ class JMoleculesDddRulesUnitTest {
 						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregate", AnnotatedAggregate.class, null) //
 
 //							To be fixed:
-//						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInCollection", Collection.class, OtherAnnotatedAggregate.class) //
+//						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInCollection", Collection.class, Association.class), //
+//						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInMap", Map.class, Association.class) //
 //						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedEntity", AnnotatedEntity.class, null) //
 //						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedEntityInCollection", Collection.class, AnnotatedEntity.class) //
 				);
@@ -136,6 +137,7 @@ class JMoleculesDddRulesUnitTest {
 		Long id;
 		AnnotatedAggregate invalidAnnotatedAggregate;
 		Collection<AnnotatedAggregate> invalidAnnotatedAggregateInCollection;
+		Map<String, AnnotatedAggregate> invalidAnnotatedAggregateInMap;
 		AnnotatedEntity invalidAnnotatedEntity;
 		Collection<AnnotatedEntity> invalidAnnoatedEntityInCollection;
 	}

--- a/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesDddRulesUnitTest.java
+++ b/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesDddRulesUnitTest.java
@@ -65,7 +65,9 @@ class JMoleculesDddRulesUnitTest {
 						violation(SampleValueObject.class, "annotatedEntity", AnnotatedEntity.class, null),
 						violation(SampleValueObject.class, "aggregate", SampleAggregate.class, null),
 						violation(SampleValueObject.class, "annotatedAggregate", AnnotatedAggregate.class, null),
-						violation(SampleGrandChildEntity.class, "otherEntity", OtherEntity.class, OtherAggregate.class) // GH-222
+						violation(SampleGrandChildEntity.class, "otherEntity", OtherEntity.class, OtherAggregate.class), // GH-222
+						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregate", AnnotatedAggregate.class, null), //
+						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInCollection", Collection.class, OtherAnnotatedAggregate.class) //
 				);
 	}
 
@@ -123,4 +125,13 @@ class JMoleculesDddRulesUnitTest {
 		SampleAggregate aggregate;
 		AnnotatedAggregate annotatedAggregate;
 	}
+
+	@org.jmolecules.ddd.annotation.AggregateRoot
+	static class OtherAnnotatedAggregate {
+		@org.jmolecules.ddd.annotation.Identity
+		Long id;
+		AnnotatedAggregate invalidAnnotatedAggregate;
+		Collection<AnnotatedAggregate> invalidAnnotatedAggregateInCollection;
+	}
+
 }

--- a/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesDddRulesUnitTest.java
+++ b/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesDddRulesUnitTest.java
@@ -66,11 +66,11 @@ class JMoleculesDddRulesUnitTest {
 						violation(SampleValueObject.class, "aggregate", SampleAggregate.class, null),
 						violation(SampleValueObject.class, "annotatedAggregate", AnnotatedAggregate.class, null),
 						violation(SampleGrandChildEntity.class, "otherEntity", OtherEntity.class, OtherAggregate.class), // GH-222
-						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregate", AnnotatedAggregate.class, null) //
+						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregate", AnnotatedAggregate.class, null), //
+						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInCollection", Collection.class, Association.class), //
+						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInMap", Map.class, Association.class) //
 
 //							To be fixed:
-//						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInCollection", Collection.class, Association.class), //
-//						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInMap", Map.class, Association.class) //
 //						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedEntity", AnnotatedEntity.class, null) //
 //						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedEntityInCollection", Collection.class, AnnotatedEntity.class) //
 				);

--- a/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesDddRulesUnitTest.java
+++ b/jmolecules-archunit/src/test/java/org/jmolecules/archunit/JMoleculesDddRulesUnitTest.java
@@ -66,8 +66,12 @@ class JMoleculesDddRulesUnitTest {
 						violation(SampleValueObject.class, "aggregate", SampleAggregate.class, null),
 						violation(SampleValueObject.class, "annotatedAggregate", AnnotatedAggregate.class, null),
 						violation(SampleGrandChildEntity.class, "otherEntity", OtherEntity.class, OtherAggregate.class), // GH-222
-						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregate", AnnotatedAggregate.class, null), //
-						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInCollection", Collection.class, OtherAnnotatedAggregate.class) //
+						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregate", AnnotatedAggregate.class, null) //
+
+//							To be fixed:
+//						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedAggregateInCollection", Collection.class, OtherAnnotatedAggregate.class) //
+//						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedEntity", AnnotatedEntity.class, null) //
+//						violation(OtherAnnotatedAggregate.class, "invalidAnnotatedEntityInCollection", Collection.class, AnnotatedEntity.class) //
 				);
 	}
 
@@ -132,6 +136,16 @@ class JMoleculesDddRulesUnitTest {
 		Long id;
 		AnnotatedAggregate invalidAnnotatedAggregate;
 		Collection<AnnotatedAggregate> invalidAnnotatedAggregateInCollection;
+		AnnotatedEntity invalidAnnotatedEntity;
+		Collection<AnnotatedEntity> invalidAnnoatedEntityInCollection;
+	}
+
+	@org.jmolecules.ddd.annotation.AggregateRoot
+	static class ThirdAnnotatedAggregate {
+		@org.jmolecules.ddd.annotation.Identity
+		Long id;
+
+		AnnotatedEntity valid;
 	}
 
 }


### PR DESCRIPTION
Reproducing issues signaled in #253 


The MR contained testing cases for the filing scenarios, commented out for now.


---

When it comes to validating the annotated classes, _JMoleculesDddRules_ fails to catch the violation for an aggregate referencing a Collection of other aggregates as shown below: 

```java
@AggregateRoot 
class AnnotatedAggregate { ... }

@AggregateRoot
class OtherAnnotatedAggregate {
    AnnotatedAggregate invalidAnnotatedAggregate; // <-- throws violation (correct)
    Collection<AnnotatedAggregate> invalidAnnotatedAggregateInCollection; // <-- doesn't throw violation (not correct)
}
```

PS: this works ok for the interfaces, and only fails with the annotations. Also, I believe it can be interesting to have that same test/assertions run against two set of objects (one using the interfaces and its equivalent that uses annotations).

This rule also seems to be skipped when it comes to annotated objects: _Aggregates only refer to entities that are declared to be part of it_

```java
@AggregateRoot
static class SomeAnnotatedAggregate {
    // ...
    AnnotatedEntity valid;
}

@AggregateRoot
static class OtherAnnotatedAggregate {
    AnnotatedEntity invalidAnnotatedEntity; // <-- doesn't throw violation (not correct)
    Collection<AnnotatedEntity> invalidAnnoatedEntityInCollection; // <-- doesn't throw violation (not correct)
}
```
