### PR TITLE
Prevent `NullPointerException` by filtering missing `@Generated` annotation classes from `AT_GENERATED`

### DIFF
--- a/jmolecules-bytebuddy/src/main/java/org/jmolecules/bytebuddy/Types.java
+++ b/jmolecules-bytebuddy/src/main/java/org/jmolecules/bytebuddy/Types.java
@@ -18,6 +18,7 @@ package org.jmolecules.bytebuddy;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.stream.Collectors;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.springframework.lang.Nullable;
@@ -39,6 +40,7 @@ class Types {
 				"javax.annotation.processing.Generated",
 				"javax.annotation.Generated")
 				.<Class<? extends Annotation>> map(Types::loadIfPresent)
+				.filter(Objects::nonNull)
 				.collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
### Summary

The static initializer in `Types` may insert `null` values into `AT_GENERATED` when one or more `@Generated` annotation classes are not present on the classpath.

```
static {
    DOMAIN_EVENT_HANDLER = loadIfPresent("org.jmolecules.event.annotation.DomainEventHandler");
    AT_GENERATED = Stream.of(
            "org.springframework.aot.generate.Generated",
            "javax.annotation.processing.Generated",
            "javax.annotation.Generated")
        .<Class<? extends Annotation>>map(Types::loadIfPresent)
        .collect(Collectors.toList());
}
```

### Problem
If any of the above annotation classes are missing, `loadIfPresent(…)` returns `null`, causing `AT_GENERATED` to contain `null` entries.
This can result in a `NullPointerException` when `AT_GENERATED` is iterated over in [PluginUtils](https://github.com/xmolecules/jmolecules-integrations/blob/10bee9210530bf695f7e5b8b2b8ba11346a1a8a0/jmolecules-bytebuddy/src/main/java/org/jmolecules/bytebuddy/PluginUtils.java#L373-L389)

Although these classes are typically available in the classpath, the code becomes fragile in minimal or custom environments.

### Rationale
If the code assumed that all these classes were always present, it wouldn’t need to call `loadIfPresent()` in the first place.
The very use of `loadIfPresent()` suggests that the intent was to include only those classes that actually exist on the classpath — therefore, filtering out `null` values aligns with the original design intent.

### Solution
Filter out null values when building the list to ensure `AT_GENERATED` only contains valid class references:

```
AT_GENERATED = Stream.of(
        "org.springframework.aot.generate.Generated",
        "javax.annotation.processing.Generated",
        "javax.annotation.Generated")
    .map(Types::loadIfPresent)
    .filter(Objects::nonNull)
    .collect(Collectors.toList());

```

This prevents potential NullPointerExceptions while preserving existing behavior.

### Impact
- Prevents unexpected runtime failures in reduced or custom classpath setups.
- No behavioral change for normal environments where all classes are present.