### PR TITLE
GH-382 - Fix RecordInstantiator for Hibernate 7

### DIFF
--- a/jmolecules-jpa/src/main/java/org/jmolecules/hibernate/RecordInstantiator.java
+++ b/jmolecules-jpa/src/main/java/org/jmolecules/hibernate/RecordInstantiator.java
@@ -26,13 +26,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.hibernate.Version;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.spi.EmbeddableInstantiator;
 import org.hibernate.metamodel.spi.ValueAccess;
 
 /**
- * Hibernate 6 specific {@link EmbeddableInstantiator} that inspects a {@link Record} for its {@link RecordComponent}s
- * to assemble instances of it in {@link #instantiate(Supplier, SessionFactoryImplementor)}. To use it directly, declare
+ * Hibernate 7 specific {@link EmbeddableInstantiator} that inspects a {@link Record} for its {@link RecordComponent}s
+ * to assemble instances of it in {@link #instantiate(ValueAccess)}. To use it directly, declare
  * a subclass of it invoking {@link RecordInstantiator}'s constructor with the record type at hand and use that declared
  * types via {@link org.hibernate.annotations.EmbeddableInstantiator} on the record type.
  *
@@ -78,7 +77,7 @@ public class RecordInstantiator implements EmbeddableInstantiator {
 	 * @see org.hibernate.metamodel.spi.Instantiator#isInstance(java.lang.Object, org.hibernate.engine.spi.SessionFactoryImplementor)
 	 */
 	@Override
-	public boolean isInstance(Object object, SessionFactoryImplementor sessionFactory) {
+	public boolean isInstance(Object object) {
 		return type.isInstance(object);
 	}
 
@@ -87,7 +86,7 @@ public class RecordInstantiator implements EmbeddableInstantiator {
 	 * @see org.hibernate.metamodel.spi.Instantiator#isSameClass(java.lang.Object, org.hibernate.engine.spi.SessionFactoryImplementor)
 	 */
 	@Override
-	public boolean isSameClass(Object object, SessionFactoryImplementor sessionFactory) {
+	public boolean isSameClass(Object object) {
 		return type.equals(object.getClass());
 	}
 
@@ -96,7 +95,7 @@ public class RecordInstantiator implements EmbeddableInstantiator {
 	 * @see org.hibernate.metamodel.spi.EmbeddableInstantiator#instantiate(org.hibernate.metamodel.spi.ValueAccess, org.hibernate.engine.spi.SessionFactoryImplementor)
 	 */
 	@Override
-	public Object instantiate(ValueAccess access, SessionFactoryImplementor factory) {
+	public Object instantiate(ValueAccess access) {
 
 		Object[] sources = access.getValues();
 

--- a/jmolecules-jpa/src/test/java/org/jmolecules/hibernate/RecordInstantiatorUnitTests.java
+++ b/jmolecules-jpa/src/test/java/org/jmolecules/hibernate/RecordInstantiatorUnitTests.java
@@ -40,7 +40,7 @@ class RecordInstantiatorUnitTests {
 		ValueAccess access = mock(ValueAccess.class);
 		doReturn(values).when(access).getValues();
 
-		assertThat(instantiator.instantiate(access, null))
+		assertThat(instantiator.instantiate(access))
 				.isEqualTo(new Person("Matthews", 57, "Dave"));
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<aptk-tools.version>0.30.5</aptk-tools.version>
 		<archunit.version>1.4.1</archunit.version>
 		<bytebuddy.version>1.18.1</bytebuddy.version>
-		<hibernate.version>6.6.36.Final</hibernate.version>
+		<hibernate.version>7.0.10.Final</hibernate.version>
 		<java.version>17</java.version>
 		<jmolecules.version>1.10.0</jmolecules.version>
 		<jmolecules-next.version>2.0.1</jmolecules-next.version>


### PR DESCRIPTION
- Upgrade Hibernate to 7.0.10.Final
- Remove `SessionFactoryImplementor sessionFactory` params from RecordInstantiator

Fixes #382 