### PR TITLE
GH-398 - Fix Association deserialization with implicit property-based creators

### DIFF
--- a/jmolecules-jackson3/src/main/java/org/jmolecules/jackson3/SingleValueWrappingTypeDeserializerModifier.java
+++ b/jmolecules-jackson3/src/main/java/org/jmolecules/jackson3/SingleValueWrappingTypeDeserializerModifier.java
@@ -23,16 +23,25 @@ import tools.jackson.databind.DeserializationConfig;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.BeanDeserializerBuilder;
+import tools.jackson.databind.deser.SettableBeanProperty;
 import tools.jackson.databind.deser.ValueDeserializerModifier;
+import tools.jackson.databind.deser.ValueInstantiator;
+import tools.jackson.databind.deser.impl.MethodProperty;
 import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.introspect.AnnotatedField;
+import tools.jackson.databind.introspect.AnnotatedMember;
+import tools.jackson.databind.introspect.AnnotatedMethod;
 import tools.jackson.databind.introspect.BeanPropertyDefinition;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
 import org.jmolecules.ddd.annotation.ValueObject;
+import org.jmolecules.ddd.types.Association;
 import org.jmolecules.ddd.types.Identifier;
 import org.springframework.beans.BeanUtils;
 import org.springframework.util.ReflectionUtils;
@@ -47,6 +56,93 @@ class SingleValueWrappingTypeDeserializerModifier extends ValueDeserializerModif
 
 	private static final long serialVersionUID = 5297887920996219863L;
 	private static final AnnotationDetector DETECTOR = AnnotationDetector.getAnnotationDetector();
+
+	/*
+	 * (non-Javadoc)
+	 * @see tools.jackson.databind.deser.ValueDeserializerModifier#updateBuilder(tools.jackson.databind.DeserializationConfig, tools.jackson.databind.BeanDescription.Supplier, tools.jackson.databind.deser.BeanDeserializerBuilder)
+	 */
+	@Override
+	public BeanDeserializerBuilder updateBuilder(DeserializationConfig config, Supplier supplier,
+			BeanDeserializerBuilder builder) {
+
+		ValueInstantiator instantiator = builder.getValueInstantiator();
+
+		if (!instantiator.canCreateFromObjectWith()) {
+			return builder;
+		}
+
+		SettableBeanProperty[] creatorProps = instantiator.getFromObjectArguments(config);
+
+		if (creatorProps == null) {
+			return builder;
+		}
+
+		BeanDescription beanDesc = supplier.get();
+		Class<?> beanClass = beanDesc.getBeanClass();
+
+		for (SettableBeanProperty creatorProp : creatorProps) {
+
+			Field field = ReflectionUtils.findField(beanClass, creatorProp.getName());
+
+			if (field == null
+					|| !Association.class.isAssignableFrom(field.getType())
+					|| Association.class.isAssignableFrom(creatorProp.getType().getRawClass())) {
+				continue;
+			}
+
+			// GH-398: Jackson 3 selected a constructor as an implicit property-based creator
+			// whose parameter type does not match the Association-typed bean property.
+			// Disable the property-based creator so Jackson falls back to no-arg constructor
+			// and setter/field-based population, which correctly uses AssociationDeserializer.
+			builder.setValueInstantiator(new DefaultOnlyInstantiator(instantiator));
+
+			// Also replace the wrongly-typed property in the builder with one derived from
+			// the setter or field, which has the correct Association type.
+			replacePropertyFromMutator(beanDesc, builder, creatorProp.getName());
+
+			return builder;
+		}
+
+		return builder;
+	}
+
+	/**
+	 * Replaces the property with the given name in the builder with one created from the
+	 * bean's setter or field, which has the correct type.
+	 */
+	private static void replacePropertyFromMutator(BeanDescription beanDesc,
+			BeanDeserializerBuilder builder, String propertyName) {
+
+		for (BeanPropertyDefinition propDef : beanDesc.findProperties()) {
+
+			if (!propDef.getName().equals(propertyName)) {
+				continue;
+			}
+
+			AnnotatedMember mutator = propDef.getNonConstructorMutator();
+
+			if (mutator == null) {
+				break;
+			}
+
+			JavaType correctType;
+
+			if (mutator instanceof AnnotatedMethod) {
+				correctType = ((AnnotatedMethod) mutator).getParameterType(0);
+			} else if (mutator instanceof AnnotatedField) {
+				correctType = ((AnnotatedField) mutator).getType();
+			} else {
+				break;
+			}
+
+			MethodProperty replacement = new MethodProperty(propDef, correctType, null,
+					beanDesc.getClassAnnotations(), mutator);
+
+			builder.addOrReplaceProperty(replacement, true);
+
+			break;
+		}
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -118,6 +214,32 @@ class SingleValueWrappingTypeDeserializerModifier extends ValueDeserializerModif
 
 	private interface ThrowingFunction {
 		Object apply(Object source) throws Exception;
+	}
+
+	/**
+	 * A {@link ValueInstantiator} wrapper that disables property-based creation, falling back to
+	 * default (no-arg) construction. Used when Jackson 3 incorrectly selects a constructor as an
+	 * implicit property-based creator whose parameter types don't match the bean's
+	 * {@link Association}-typed properties.
+	 *
+	 * @author Oliver Drotbohm
+	 * @see <a href="https://github.com/xmolecules/jmolecules-integrations/issues/398">GH-398</a>
+	 */
+	private static class DefaultOnlyInstantiator extends ValueInstantiator.Delegating {
+
+		DefaultOnlyInstantiator(ValueInstantiator delegate) {
+			super(delegate);
+		}
+
+		@Override
+		public boolean canCreateFromObjectWith() {
+			return false;
+		}
+
+		@Override
+		public SettableBeanProperty[] getFromObjectArguments(DeserializationConfig config) {
+			return null;
+		}
 	}
 
 	private static class InstantiatorDeserializer extends StdDeserializer<Object> {

--- a/jmolecules-jackson3/src/test/java/org/jmolecules/jackson3/JMoleculesModuleUnitTests.java
+++ b/jmolecules-jackson3/src/test/java/org/jmolecules/jackson3/JMoleculesModuleUnitTests.java
@@ -28,6 +28,7 @@ import tools.jackson.databind.json.JsonMapper;
 import java.util.UUID;
 
 import org.jmolecules.ddd.annotation.ValueObject;
+import org.jmolecules.ddd.types.AggregateRoot;
 import org.jmolecules.ddd.types.Association;
 import org.jmolecules.ddd.types.Identifier;
 import org.junit.jupiter.api.Test;
@@ -101,6 +102,19 @@ class JMoleculesModuleUnitTests {
 		assertThat(wrapper.getId()).isNotNull();
 	}
 
+	@Test // GH-398
+	void deserializesAssociationWithImplicitCreator() throws Exception {
+
+		var uuidSource = "fe6f3370-5551-4251-86d3-b4db049a7ddd";
+		var uuid = UUID.fromString(uuidSource);
+
+		var result = mapper.readValue(
+				"{ \"customer\" : \"" + uuidSource + "\" }",
+				OrderWithPublicConstructor.class);
+
+		assertThat(result.getCustomer()).isEqualTo(Association.forId(SampleIdentifier.of(uuid)));
+	}
+
 	@Test // GH-347
 	void canBeFoundAndAddedDynamically() {
 
@@ -163,5 +177,48 @@ class JMoleculesModuleUnitTests {
 	@Data
 	static class Wrapper {
 		First first;
+	}
+
+	// GH-398
+
+	static class SampleAggregate implements AggregateRoot<SampleAggregate, SampleIdentifier> {
+
+		private final SampleIdentifier id;
+
+		SampleAggregate(SampleIdentifier id) {
+			this.id = id;
+		}
+
+		@Override
+		public SampleIdentifier getId() {
+			return id;
+		}
+	}
+
+	/**
+	 * Simulates a domain entity with a public constructor whose parameter name matches an
+	 * {@link Association}-typed bean property. Jackson 3 incorrectly selects such constructors as
+	 * implicit property-based creators, causing deserialization failures because the constructor
+	 * parameter type ({@code SampleAggregate}) does not match the bean property type
+	 * ({@code Association<SampleAggregate, SampleIdentifier>}).
+	 */
+	static class OrderWithPublicConstructor {
+
+		private Association<SampleAggregate, SampleIdentifier> customer;
+
+		OrderWithPublicConstructor() {
+		}
+
+		public OrderWithPublicConstructor(SampleAggregate customer) {
+			this.customer = Association.forAggregate(customer);
+		}
+
+		public Association<SampleAggregate, SampleIdentifier> getCustomer() {
+			return customer;
+		}
+
+		public void setCustomer(Association<SampleAggregate, SampleIdentifier> customer) {
+			this.customer = customer;
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #398.

When Jackson 3 auto-detects a public parameterized constructor as an implicit property-based creator, it uses the constructor parameter types for deserialization. This causes failures when the constructor parameter type (e.g. an `AggregateRoot`) differs from the bean property type (`Association`).

This commonly occurs with jMolecules ByteBuddy plugin, which adds public no-arg constructors to entity classes for JPA. Jackson 3 then sees both the no-arg constructor and the original public parameterized constructor, selecting the latter as an implicit creator.

### Changes

- **`SingleValueWrappingTypeDeserializerModifier`**: Added `updateBuilder()` override that detects when a property-based creator parameter type mismatches an `Association`-typed bean property, and:
  1. Disables the implicit property-based creator (wraps `ValueInstantiator` to return `false` for `canCreateFromObjectWith()`)
  2. Replaces the wrongly-typed property in the builder with one derived from the setter or field (which has the correct `Association` type)

- **`JMoleculesModuleUnitTests`**: Added test reproducing the issue with a class that has a public constructor whose parameter name matches an `Association`-typed field.

## Test plan

- [x] New test `deserializesAssociationWithImplicitCreator` passes
- [x] All existing tests pass (9 tests, 0 failures)